### PR TITLE
Update required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ or:
 `source <path to virtualenv>/bin/activate.csh # for (t)csh-shells`
 
 then:
-
+`pip3 install numpy`
 `pip3 install -r requirements.txt`
 
+Numpy needs to be installated separately or the latter command will
+fail.
+Depending on your distribution you may also have to install development packages for libhdf4 and python.
 If you want to compute atmospheric transmissions, you will need to get and install libRadtran from http://www.libradtran.org/doku.php?id=download
 Only the basic program is needed at this time, none of the additional modules are needed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 astropy
+scipy
+pydap
+requests
 netCDF4
 matplotlib
 pytest


### PR DESCRIPTION
While trying to run the code I noticed that a number of dependencies were missing from both requirements.txt (Python modules) and required non-pip packages (libhdf4-dev, python3-dev and python3-numpy, on Linux Mint).

This PR adds the missing Python packages to requirements.txt and the rest to README.md. It would perhaps be ideal if numpy was included in requirements.txt but this fails as python-hdf4 will not install, causing the entire pip install command to fail, unless numpy has already been installed beforehand.

At least on my system, the program runs fine with these changes. Let me know if something's wrong here.